### PR TITLE
Typescript defs & raw API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A WebAssembly implementation of xxHash",
   "main": "cjs/xxhash-wasm.js",
   "module": "esm/xxhash-wasm.js",
+  "types": "./types.d.ts",
   "author": "Michael Jungo <michaeljungo92@gmail.com>",
   "license": "MIT",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,9 @@ function writeBufferToMemory(buffer, memory, offset) {
 
 async function xxhash() {
   const {
-    instance: { exports: { mem, xxh32, xxh64 } }
+    instance: {
+      exports: { mem, xxh32, xxh64 }
+    }
   } = await WebAssembly.instantiate(wasmBytes);
   function h32Raw(inputBuffer, seed = 0) {
     writeBufferToMemory(inputBuffer, mem, 0);

--- a/src/index.js
+++ b/src/index.js
@@ -22,30 +22,52 @@ async function xxhash() {
   const {
     instance: { exports: { mem, xxh32, xxh64 } }
   } = await WebAssembly.instantiate(wasmBytes);
+  function h32Raw(inputBuffer, seed = 0) {
+    writeBufferToMemory(inputBuffer, mem, 0);
+    // Logical shift right makes it an u32, otherwise it's interpreted as
+    // an i32.
+    return xxh32(0, inputBuffer.byteLength, seed) >>> 0;
+  }
+
+  function h32(str, seed = 0) {
+    const strBuffer = encoder.encode(str);
+    return h32Raw(strBuffer, seed).toString(16);
+  }
+
+  function h64RawToDataView(inputBuffer, seedHigh = 0, seedLow = 0) {
+    writeBufferToMemory(inputBuffer, mem, 8);
+    // The first word (64-bit) is used to communicate an u64 between
+    // JavaScript and WebAssembly. First the seed will be set from
+    // JavaScript and afterwards the result will be set from WebAssembly.
+    const dataView = new DataView(mem.buffer);
+    dataView.setUint32(0, seedHigh, true);
+    dataView.setUint32(4, seedLow, true);
+    xxh64(0, inputBuffer.byteLength);
+    return dataView;
+  }
+
+  function h64Raw(inputBuffer, seedHigh = 0, seedLow = 0) {
+    return new Uint8Array(
+      h64RawToDataView(inputBuffer, seedHigh, seedLow).buffer,
+      0,
+      8
+    );
+  }
+
+  function h64(str, seedHigh = 0, seedLow = 0) {
+    const strBuffer = encoder.encode(str);
+    const dataView = h64RawToDataView(strBuffer, seedHigh, seedLow);
+    const h64str =
+      dataView.getUint32(0, true).toString(16) +
+      dataView.getUint32(4, true).toString(16);
+    return h64str;
+  }
+
   return {
-    h32(str, seed = 0) {
-      const strBuffer = encoder.encode(str);
-      writeBufferToMemory(strBuffer, mem, 0);
-      // Logical shift right makes it an u32, otherwise it's interpreted as
-      // an i32.
-      const h32 = xxh32(0, strBuffer.byteLength, seed) >>> 0;
-      return h32.toString(16);
-    },
-    h64(str, seedHigh = 0, seedLow = 0) {
-      const strBuffer = encoder.encode(str);
-      writeBufferToMemory(strBuffer, mem, 8);
-      // The first word (64-bit) is used to communicate an u64 between
-      // JavaScript and WebAssembly. First the seed will be set from
-      // JavaScript and afterwards the result will be set from WebAssembly.
-      const dataView = new DataView(mem.buffer);
-      dataView.setUint32(0, seedHigh, true);
-      dataView.setUint32(4, seedLow, true);
-      xxh64(0, strBuffer.byteLength);
-      const h64 =
-        dataView.getUint32(0, true).toString(16) +
-        dataView.getUint32(4, true).toString(16);
-      return h64;
-    }
+    h32,
+    h32Raw,
+    h64,
+    h64Raw
   };
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,10 +34,29 @@ for (const testCase of testCases) {
     t.is(h32, testCase.h32);
   });
 
+  test(`h32Raw of ${testCase.input}`, async t => {
+    const encoder = new TextEncoder();
+    const hasher = await xxhash();
+    const h32 = hasher.h32Raw(encoder.encode(testCase.input)).toString(16);
+    t.is(h32, testCase.h32);
+  });
+
   test(`h64 of ${testCase.input}`, async t => {
     const hasher = await xxhash();
     const h64 = hasher.h64(testCase.input);
     t.is(h64, testCase.h64);
+  });
+
+  test(`h64Raw of ${testCase.input}`, async t => {
+    const encoder = new TextEncoder();
+    const hasher = await xxhash();
+    const h64uint8array = hasher.h64Raw(encoder.encode(testCase.input));
+    t.is(h64uint8array.length, 8);
+    const dataView = new DataView(h64uint8array.buffer);
+    const h64str =
+      dataView.getUint32(0, true).toString(16) +
+      dataView.getUint32(4, true).toString(16);
+    t.is(h64str, testCase.h64);
   });
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,9 @@
 declare module 'xxhash-wasm' {
     type Exports = {
         h32(input: string, seed?: number): string;
+        h32Raw(inputBuffer: Uint8Array, seed?: number): number;
         h64(input: string, seedHigh?: number, seedLow?: number): string;
+        h64Raw(inputBuffer: Uint8Array, seedHigh?: number, seedLow?: number): Uint8Array;
     };
     export default function xxhash(): Promise<Exports>;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,7 @@
+declare module 'xxhash-wasm' {
+    type Exports = {
+        h32(input: string, seed?: number): string;
+        h64(input: string, seedHigh?: number, seedLow?: number): string;
+    };
+    export default function xxhash(): Promise<Exports>;
+}


### PR DESCRIPTION
Hi there, thanks for making this high performance implementation of xxhash so readily usable from JS!

In my use case, I needed to hash raw data (Uint8Arrays) instead of strings and also wanted the hash as pure data. Luckily, I was able to just change the interfacing JS file to add corresponding API functions - without touching the WASM and its build process.

Because I'm using it in a TypeScript project, I also added definitions for everything.

I added some pretty brain-dead tests for my new API functions, which essentially just reuse the string test cases. It might be good to also have at least a couple pure data test cases.