### PR TITLE
Limit dependency on TextEncoder existing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@
 // eslint-disable-next-line no-undef
 const wasmBytes = new Uint8Array(WASM_PRECOMPILED_BYTES);
 
-const encoder = new TextEncoder();
+let encoder;
 
 function writeBufferToMemory(buffer, memory, offset) {
   if (memory.buffer.byteLength < buffer.byteLength + offset) {
@@ -32,6 +32,7 @@ async function xxhash() {
   }
 
   function h32(str, seed = 0) {
+    if (!encoder) encoder = new TextEncoder();
     const strBuffer = encoder.encode(str);
     return h32Raw(strBuffer, seed).toString(16);
   }
@@ -57,6 +58,7 @@ async function xxhash() {
   }
 
   function h64(str, seedHigh = 0, seedLow = 0) {
+    if (!encoder) encoder = new TextEncoder();
     const strBuffer = encoder.encode(str);
     const dataView = h64RawToDataView(strBuffer, seedHigh, seedLow);
     const h64str =


### PR DESCRIPTION
In my use case, I'm only using the raw (Uint8Array) API, and in some environments, TextEncoder is not defined as a global (as it is in the Browser and NodeJS) - it doesn't exist at all.

Here, I deferred initialization of TextEncoder to the functions that actually need it.