### PR TITLE
Add support for Typescript's `nodenext` module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./cjs/xxhash-wasm.cjs",
   "module": "./esm/xxhash-wasm.js",
   "exports": {
+    "types": "./types.d.ts",
     "import": "./esm/xxhash-wasm.js",
     "require": "./cjs/xxhash-wasm.cjs"
   },


### PR DESCRIPTION
See: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

For packages that define `exports`, the new typescript module resolution mode checks there for type definitions. This change will allow the existing type definitions to be discovered by packages using this mode.