### PR TITLE
perf: set state with `.subarray()` over `.slice()` to avoid copy

### DIFF
--- a/src/xxhash.js
+++ b/src/xxhash.js
@@ -64,7 +64,7 @@ export function xxhash(instance) {
 
     // Each time we interact with wasm, it may have mutated our state so we'll
     // need to read it back into our closed copy.
-    state.set(memory.slice(0, size));
+    state.set(memory.subarray(0, size));
 
     return {
       update(input) {
@@ -80,7 +80,7 @@ export function xxhash(instance) {
           length = input.byteLength;
         }
         update(0, size, length);
-        state.set(memory.slice(0, size));
+        state.set(memory.subarray(0, size));
         return this;
       },
       digest() {


### PR DESCRIPTION
[`.subarray()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray) returns a new typed array on the same ArrayBuffer, so this avoids a copy of the memory when setting the current state.

This was proposed in #49 but as it was coupled to other changes that were never separated or cleaned up, it was never merged. So this just takes the performance improvements from avoiding to create an unnecessary copy that will be discarded right afterwards.